### PR TITLE
Fix for "Invalid type for `rate`" error

### DIFF
--- a/bitmovin_api_sdk/models/stream_infos_details.py
+++ b/bitmovin_api_sdk/models/stream_infos_details.py
@@ -96,7 +96,7 @@ class StreamInfosDetails(object):
             'media_type': 'MediaType',
             'width': 'int',
             'height': 'int',
-            'rate': 'int',
+            'rate': 'float',
             'codec': 'LiveEncodingCodec',
             'samples_read_per_second_min': 'float',
             'samples_read_per_second_max': 'float',


### PR DESCRIPTION
Fix for "Invalid type for `rate`, type has to be `int`" error

When trying to do the following: 

bitmovin_api = BitmovinApi(api_key=api_key, logger=BitmovinApiLogger())
bitmovin_api.encoding.statistics.encodings.live_statistics.streams.list(encoding_id)


it raises a BitmovinError because the API returns something like 
"rate": 30.0